### PR TITLE
i50: StoreUserDataReducer assumes github is first provider

### DIFF
--- a/lib/models/auth/user_data.dart
+++ b/lib/models/auth/user_data.dart
@@ -34,7 +34,7 @@ abstract class UserData extends Object
   bool get isEmailVerified;
   BuiltList<AuthProviderData> get providers;
 
-  // TODO memoize this
+  @memoized
   bool get hasGitHub =>
       providerId == 'github.com' ||
       providers

--- a/test/unit_tests/user_data_test.dart
+++ b/test/unit_tests/user_data_test.dart
@@ -1,0 +1,70 @@
+import 'package:adventures_in_tech_world/models/auth/auth_provider_data.dart';
+import 'package:adventures_in_tech_world/models/auth/user_data.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('UserData', () {
+    test('.hasGitHub checks providerId and providers list', () {
+      final userData = UserData(
+          uid: 'uid',
+          providerId: 'provider',
+          displayName: 'andy',
+          photoUrl: 'url',
+          email: 'email@email.email',
+          phoneNumber: '0423123421',
+          createdOn: DateTime.now(),
+          lastSignedInOn: DateTime.now(),
+          isAnonymous: false,
+          isEmailVerified: false,
+          providers: BuiltList(<AuthProviderData>[
+            AuthProviderData(
+                providerId: 'firebase',
+                uid: 'uid1234',
+                displayName: 'sam',
+                photoUrl: 'url2',
+                email: 'a@a.com',
+                phoneNumber: '1234')
+          ]));
+
+      expect(userData.hasGitHub, false);
+
+      final userData2 = userData.rebuild((b) => b..providerId = 'github.com');
+
+      expect(userData2.hasGitHub, true);
+
+      final userData3 = userData.rebuild((b) => b
+        ..providers.first =
+            b.providers.first.rebuild((b) => b..providerId = 'github.com'));
+
+      expect(userData3.hasGitHub, true);
+    });
+
+    test('.hasGitHub (memoized) returns the same value on subsequent calls',
+        () {
+      final userData = UserData(
+          uid: 'uid',
+          providerId: 'firebase',
+          displayName: 'andy',
+          photoUrl: 'url',
+          email: 'email@email.email',
+          phoneNumber: '0423123421',
+          createdOn: DateTime.now(),
+          lastSignedInOn: DateTime.now(),
+          isAnonymous: false,
+          isEmailVerified: false,
+          providers: BuiltList(<AuthProviderData>[
+            AuthProviderData(
+                providerId: 'github.com',
+                uid: 'github.com',
+                displayName: 'sam',
+                photoUrl: 'url2',
+                email: 'a@a.com',
+                phoneNumber: '1234')
+          ]));
+
+      expect(userData.hasGitHub, true);
+      expect(userData.hasGitHub, true);
+    });
+  });
+}


### PR DESCRIPTION
fixes #50 

A function that checks appropriately for github as a provider was added in a previous PR but it is fairly expensive and potentially used quite a bit so we: 
- memoized hasGitHub function