### PR TITLE
i85, i87, i88: Retrieve stored token and fix sign out

### DIFF
--- a/lib/enums/auth/auth_step.dart
+++ b/lib/enums/auth/auth_step.dart
@@ -9,7 +9,8 @@ class AuthStep extends EnumClass {
   static Serializer<AuthStep> get serializer => _$authStepSerializer;
   static const AuthStep checking = _$checking;
   static const AuthStep signingInAnonymously = _$signingInAnonymously;
-  static const AuthStep checkingForGitHubToken = _$checkingForGitHubToken;
+  static const AuthStep listeningForTempToken = _$listeningForTempToken;
+  static const AuthStep retrievingStoredToken = _$retrievingStoredToken;
   static const AuthStep waitingForInput = _$waitingForInput;
   static const AuthStep requestingGitHubAuth = _$requestingGitHubAuth;
   static const AuthStep exchangingCode = _$exchangingCode;
@@ -20,13 +21,14 @@ class AuthStep extends EnumClass {
   static const Map<AuthStep, int> _$indexMap = {
     checking: 0,
     signingInAnonymously: 1,
-    checkingForGitHubToken: 2,
-    waitingForInput: 3,
-    requestingGitHubAuth: 4,
-    exchangingCode: 5,
-    exchangedCode: 6,
-    signingInWithGitHub: 7,
-    signingOut: 8
+    listeningForTempToken: 2,
+    retrievingStoredToken: 3,
+    waitingForInput: 4,
+    requestingGitHubAuth: 5,
+    exchangingCode: 6,
+    exchangedCode: 7,
+    signingInWithGitHub: 8,
+    signingOut: 9
   };
 
   const AuthStep._(String name) : super(name);

--- a/lib/reducers/auth_reducers.dart
+++ b/lib/reducers/auth_reducers.dart
@@ -1,3 +1,4 @@
+import 'package:adventures_in_tech_world/actions/auth/sign_out.dart';
 import 'package:adventures_in_tech_world/actions/auth/store_auth_step.dart';
 import 'package:adventures_in_tech_world/actions/auth/store_git_hub_token.dart';
 import 'package:adventures_in_tech_world/actions/auth/store_user_data.dart';
@@ -13,6 +14,7 @@ final authReducers = <AppState Function(AppState, dynamic)>[
   StoreUserDataReducer(),
   StoreAuthStepReducer(),
   StoreGitHubTokenReducer(),
+  SignOutReducer(),
 ];
 
 class StoreUserDataReducer extends TypedReducer<AppState, StoreUserData> {
@@ -50,4 +52,11 @@ class StoreGitHubTokenReducer extends TypedReducer<AppState, StoreGitHubToken> {
       : super((state, action) {
           return state.rebuild((b) => b..gitHubToken = action.token);
         });
+}
+
+class SignOutReducer extends TypedReducer<AppState, SignOut> {
+  SignOutReducer()
+      : super((state, action) => state.rebuild((b) => b
+          ..adventurer = null
+          ..gitHubToken = null));
 }

--- a/lib/services/auth/firebase_auth_service.dart
+++ b/lib/services/auth/firebase_auth_service.dart
@@ -34,6 +34,7 @@ class FirebaseAuthService implements AuthService {
 
     try {
       // connect the firebase auth state to the store and keep the subscription
+      _firebaseAuthStateSubscription?.cancel();
       _firebaseAuthStateSubscription =
           _firebaseAuth.connectAuthStateToStore(_storeStreamController);
     } catch (error, trace) {

--- a/lib/services/database/database_service.dart
+++ b/lib/services/database/database_service.dart
@@ -8,4 +8,5 @@ abstract class DatabaseService {
   void connectTempTokenToStore({@required String uid});
   void disconnectTempToken();
   Future<void> deleteAnonymousAccount(String userId);
+  Future<String> retrieveStoredToken(String userId);
 }

--- a/lib/services/database/firestore_service.dart
+++ b/lib/services/database/firestore_service.dart
@@ -80,4 +80,12 @@ class FirestoreService implements DatabaseService {
         .document('/anon/$userId')
         .setData(<String, dynamic>{'delete': true});
   }
+
+  @override
+  Future<String> retrieveStoredToken(String userId) {
+    return _firestore
+        .document('/users/$userId')
+        .get()
+        .then((snapshot) => snapshot['gitHubToken'] as String);
+  }
 }

--- a/lib/widgets/auth/auth_page.dart
+++ b/lib/widgets/auth/auth_page.dart
@@ -19,8 +19,10 @@ class AuthPage extends StatelessWidget {
             return WaitingIndicator('Checking Auth State');
           case AuthStep.signingInAnonymously:
             return WaitingIndicator('Signing In Anonymously');
-          case AuthStep.checkingForGitHubToken:
-            return WaitingIndicator('Checking For GitHub token');
+          case AuthStep.listeningForTempToken:
+            return WaitingIndicator('Waiting for GitHub token');
+          case AuthStep.retrievingStoredToken:
+            return WaitingIndicator('Retrieving stored GitHub token');
           case AuthStep.signingInWithGitHub:
             return WaitingIndicator('Signing in to Firebase with GitHub');
           case AuthStep.waitingForInput:


### PR DESCRIPTION
Fixes #87
Fixes #88 
Fixes #85 

- added a service call to retrieve the stored token if already signed in,
as well as auth step enum to set UI
- updated StoreUserDataMiddleware to retrieve the stored token as needed
- added a signout reducer and remove github token and adventurer
- canceled any auth state subscription before connecting a new one